### PR TITLE
Remove bold typeface from title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Site settings
 # -----------------------------------------------------------------------------
 
-title: <b>Willow</b> team # the website title (if blank, full name will be used instead)
+title: Willow team
 first_name: 
 middle_name: 
 last_name: 


### PR DESCRIPTION
The motivation for this is that otherwise the `<b>` tags are copied verbatim to the page title:

![image](https://github.com/user-attachments/assets/1c2fb4b8-9233-4de5-ad8a-5102c65d2101)
