### PR TITLE
Change how we enter alumni

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -4,7 +4,6 @@
     profilepic: justin_carpentier.jpg
     position: Inria
     type: "faculty"
-    almuni: false
 
 "Caron":
     firstname: Stéphane 
@@ -12,7 +11,6 @@
     profilepic: stephane_caron.jpg
     position: Inria
     type: "faculty"
-    almuni: false
     
 "Chen":
     firstname: Shizhe
@@ -20,7 +18,6 @@
     profilepic: shizhe_chen.jpg
     position: Inria
     type: "faculty"
-    almuni: false
 
 "Schmid":
     firstname: Cordelia
@@ -28,7 +25,6 @@
     profilepic: cordelia_schmid.jpg
     position: Inria
     type: "faculty"
-    almuni: false
 
 "Ponce":
     firstname: Jean
@@ -36,7 +32,6 @@
     profilepic: jean_ponce.jpg
     position: ENS (PSL), NYU
     type: "faculty"
-    alumni: false
 
 "Guieu":
     firstname: Julien 
@@ -44,7 +39,6 @@
     profilepic: julien_guieu.jpg
     position: Team assistant
     type: "staff"
-    alumni: false
 
 "Perrin":
     firstname: Julie
@@ -52,7 +46,6 @@
     profilepic: nopic.jpg
     position: Project manager
     type: "staff"
-    alumni: false
     
 "Andrews":
     firstname: Roland
@@ -60,7 +53,6 @@
     profilepic: roland_andrews.jpeg
     position: PhD student, joint w. SIERRA
     type: "student"
-    alumni: false
 
 "Garcia-Pinel":
     firstname: Ricardo
@@ -68,7 +60,6 @@
     profilepic: ricardo_garcia.jpg
     position: PhD student
     type: "student"
-    alumni: false
     
 "Dümbgen":
     firstname: Frederike 
@@ -76,7 +67,6 @@
     profilepic: frederike_duembgen.png
     position: Postdoc
     type: "postdoc/engineer"
-    alumni: false
 
 "Arlaud":
     firstname: Etienne
@@ -84,7 +74,6 @@
     profilepic: etienne_arlaud.jpg
     position: Engineer
     type: "postdoc/engineer"
-    alumni: false
 
 "Wingo":
     firstname: Bruce
@@ -100,7 +89,6 @@
     profilepic: fabian_schramm.png
     position: PhD student
     type: "student"
-    alumni: false
 
 "Le Lidec":
     firstname: Quentin
@@ -108,7 +96,6 @@
     profilepic: quentin_lelidec.jpg
     position: PhD student
     type: "student"
-    alumni: false
 
 "Montaut":
     firstname: Louis
@@ -116,7 +103,6 @@
     profilepic: louis_montaut.jpg
     position: PhD student
     type: "student"
-    alumni: false
 
 "Ménager":
     firstname: Etienne
@@ -124,7 +110,6 @@
     profilepic: etienne_menager.jpg
     position: Postdoc
     type: "postdoc/engineer"
-    alumni: false
 
 "Chen":
     firstname: Zerui
@@ -132,7 +117,6 @@
     profilepic: zerui_chen.jpg
     position: PhD student
     type: "student"
-    alumni: false
 
 "Fiastre":
     firstname: Gabriel
@@ -140,7 +124,6 @@
     profilepic: gabriel_fiastre.jpg
     position: PhD student
     type: "student"
-    alumni: false
 
 "Tordjman":
     firstname: Valentin
@@ -148,7 +131,6 @@
     profilepic: valentin_tordjman.jpg
     position: Intern
     type: "student"
-    alumni: false
 
 "Ventura":
     firstname: Lucas
@@ -156,7 +138,6 @@
     profilepic: lucas_ventura.png
     position: PhD student
     type: "student"
-    alumni: false
 
 "Chabal":
     firstname: Thomas
@@ -164,4 +145,3 @@
     profilepic: thomas_chabal.jpg
     position: PhD student
     type: "student"
-    alumni: false

--- a/_includes/alumni.liquid
+++ b/_includes/alumni.liquid
@@ -1,0 +1,82 @@
+<p> <a href="https://aelnouby.github.io">Alaa El-Nouby (Apple MLR) </a></p>
+<p> <a href="https://www.linkedin.com/in/elliot-chane-sane-a97712165">Elliot Chane-Sane (LAAS-CNRS) </a></p>
+<p> <a href="https://bruno-31.github.io/">Bruno Lecouat </a></p>
+<p> <a href="https://hugocisneros.com/">Hugo Cisneros (Inicio) </a></p>
+<p> <a href="https://ylabbe.github.io/">Yann Labb&eacute; (Meta) </a></p>
+<p> <a href="https://www.linkedin.com/in/guhur/">Pierre-Louis Guhur (Pillar Technology Ventures) </a></p>
+<p> Zongmian Li </p>
+<p> <a href="https://www.di.ens.fr/robin.strudel/"> Robin Strudel (DeepMind) </a></p>
+<p> <a href="http://minttualakuijala.com/">  Minttu Alakuijala (Aalto University)</a></p>
+<p> <a href="https://alexandrearaujo.com/"> Alexandre Araujo (NYU)</a></p>
+<p> <a href="https://huyvvo.github.io/"> Van Huy Vo (Meta AI)</a></p>
+<p> <a href="https://www.linkedin.com/in/rohanbudhiraja/"> Rohan Budhiraja (SquareMind)</a></p>
+<p> <a href="https://olivier-flasseur.github.io/"> Olivier Flasseur (CNRS)</a></p>
+<p> <a href="https://www.di.ens.fr/jean-paul.laumond/"> Jean-Paul Laumond (†)</a></p>
+<p> <a href="https://www.di.ens.fr/dimitri.zhukov/"> Dimitri Zhukov (Tractable)</a></p>
+<p> <a href="https://www.di.ens.fr/thomas.eboli/"> Thomas Eboli (ENS Paris-Saclay)</a></p>
+<p> <a href="https://hassony2.github.io/">Yana Hasson (DeepMind)</a></p>
+<p> <a href="https://www.linkedin.com/in/ronan-riochet-846625a5/">Ronan Riochet (Milvue)</a></p>
+<p> <a href="https://www.irocco.info/">Ignacio Rocco (Facebook)</a></p>
+<p> <a href="http://www.cs.toronto.edu/~makarand/">Makarand Tapaswi (Wadhwani AI)</a></p>
+<p> <a href="http://www.di.ens.fr/~miech/">Antoine Miech (DeepMind)</a> </p>
+<p> <a href="https://people.eecs.berkeley.edu/~efros/">Alexei Efros (UC Berkeley)</a> </p>
+<p> <a href="https://researchweb.iiit.ac.in/~vijaykumar.r/">Vijay Kumar (Walmart Labs)</a> </p>
+<p> Th&eacute;ophile Dalens</p>
+<p> <a href="http://www.di.ens.fr/~jpeyre">Julia Peyre (Helix RE)</a> </p>
+<p> <a href="http://www.di.ens.fr/~varol">G&uuml;l Varol (Univ. of Oxford)</a> </p>
+<p> <a href="http://imagine.enpc.fr/~zagoruys/">Sergey Zagoruyko (Facebook)</a> </p>
+<p> Tuan-Hung Vu (Valeo) </p>
+<p> <a href="https://www.di.ens.fr/~trager/">Matthew Trager (NYU)</a> </p>
+<p> <a href="http://aosokin.github.io/">Anton Osokin (CS HSE)</a> </p>
+<p> <a href="http://cmp.felk.cvut.cz/~gronapet/">Petr Gronat (Avast)</a> </p><!-- ? -->
+<p> <a href="http://cvlab.postech.ac.kr/~mcho/">Minsu Cho (POSTECH)</a> </p>
+<p> <a href="http://www.di.ens.fr/~bojanowski">Piotr Bojanowski (Facebook)</a> </p>
+<p> <a href="http://vadimkantorov.com/">Vadim Kantorov</a> </p>      
+<p> Louise Benoit </p>
+<p> <a href="http://lear.inrialpes.fr/people/alahari/">Karteek Alahari (THOTH)</a> </p>
+<p> <a href="http://www.di.ens.fr/~arlot/">Sylvain Arlot (SIERRA)</a> </p>
+<p> <a href="http://imagine.enpc.fr/~aubrym/">Mathieu Aubry (&Eacute;cole des Ponts ParisTech)</a> </p>
+<p> <a href="http://certis.enpc.fr/~audibert/">Jean-Yves Audibert (SIERRA)</a> </p>
+<p> <a href="http://www.di.ens.fr/~fbach/">Francis Bach (SIERRA)</a> </p>
+<p> <a href="http://cs.nyu.edu/~ylan/">Y-Lan Boureau (Facebook)</a> </p>
+<p> <a href="http://www.di.ens.fr/~cherniav/">Neva Cherniavsky (MIT)</a> </p>
+<p> <a href="http://www.seas.upenn.edu/~timothee/">Timothee Cour (Google)</a> </p>
+<p> Vincent Delaitre (Deepomatic) </p>
+<p> <a href="http://solidware.io/?page_id=3518">Olivier Duchenne (Solidware)</a> </p>
+<p> C&eacute;cile Espiegle </p>
+<p> Loic Fevrier </p>
+<p> <a href="http://www.cse.wustl.edu/~furukawa/">Yasutaka Furukawa (Washington University)</a> </p>
+<p> Edouard Grave (Facebook) </p>
+<p> <a href="http://www.harchaoui.org/warith/">Warith Harchaoui</a> </p>
+<p> <a href="http://cbio.ensmp.fr/~thocking/">Toby Hocking (SIERRA)</a> </p>
+<p> <a href="http://www.di.ens.fr/~jenatton/">Rodolphe Jenatton (Amazon)</a> </p>
+<p> <a href="http://www.di.ens.fr/~joulin/">Armand Joulin (Facebook)</a> </p>
+<p> <a href="http://sites.google.com/site/huikongsite/Home">Hui Kong (OSU)</a> </p>
+<p> <a href="http://www.normalesup.org/~gcheron/">Guilhem Ch&eacute;ron</a> </p>
+<p> <a href="http://www.jbalayrac.com/">Jean-Baptiste Alayrac (DeepMind)</a> </p>
+<p> Rafael S. Rezende (NAVER LABS) </p>
+<p> Maxime Oquab (Facebook) </p>
+<p> <a href="http://www.di.ens.fr/~bursuc/">Andrei Bursuc (Safran)</a> </p>
+<p> <a href="http://www.relja.info/">Relja Arandjelovi&#263 (DeepMind)</a> </p>
+<p> <a href="http://bsham.github.io/">Bumsub Ham (Yonsei University)</a> </p>
+<p> <a href="http://www.di.ens.fr/~seguin">Guillaume Seguin (Regaind)</a> <p> 
+<p> Florent Couzini&eacute;-Devy </p>
+<p> Igor Kalevatykh </p>
+<p> Akash Kushal (Two Sigma Investments) </p>
+<p> <a href="http://www.di.ens.fr/~skwak/">Suha Kwak (POSTECH)</a> </p>
+<p> <a href="http://www.di.ens.fr/~lefevrea">Augustin Lefevre (SIERRA)</a> </p>
+<p> <a href="http://www.le-roux.name/">Nicolas Le Roux (Google Brain)</a> </p>
+<p> Jos&eacute; Lezama (ENS Cachan) </p>
+<p> <a href="http://www.di.ens.fr/~obozinski/">Guillaume Obozinski (&Eacute;cole des Ponts ParisTech)</a> </p>
+<p> <a href="http://www.di.ens.fr/~mairal/">Julien Mairal (THOTH)</a> </p>
+<p> <a href="http://isda.ncsa.uiuc.edu/~kmchenry/">Kenton McHenry (UIUC)</a> </p>
+<p> <a href="http://imagine.enpc.fr/~pons/">Jean-Philippe Pons (CSTB)</a> </p>
+<p> <a href="http://www.mikelrodriguez.com">Mikel Rodriguez (MITRE)</a> </p>
+<p> <a href="http://www.di.ens.fr/~russell/">Bryan Russell (Adobe)</a> </p>
+<p> Florent S&eacute;gonne (SIERRA) </p>
+<p> <a href="http://www.di.ens.fr/~chari/">Visesh Chari (Amazon)</a> </p>
+<p> <a href="http://www.di.ens.fr/~solnon/">Matthieu Solnon (SIERRA)</a> </p>
+<p> <a href="http://gr.xjtu.edu.cn/web/jiansun/">Jian Sun (Xi&rsquo;an Jiaotong University)</a> </p>
+<p> <a href="http://staff.science.uva.nl/~jvgemert/">Jan van Gemert (UVA)</a> </p>
+<p> Muhammad Muneeb Ullah </p>
+<p> <a href="http://www.oliver-whyte.com/">Oliver Whyte (Microsoft)</a> </p>

--- a/_includes/former_visitors.liquid
+++ b/_includes/former_visitors.liquid
@@ -1,0 +1,14 @@
+<p> <a href="http://www.ok.ctrl.titech.ac.jp/~torii/">Akihiko Torii</a> </p>
+<p> <a href="http://leon.bottou.org/">L&eacute;on Bottou</a> </p>
+<p> <a href="http://www.cs.cmu.edu/~santosh/">Santosh Kumar Divvala</a> </p>
+<p> <a href="http://people.csail.mit.edu/fredo/">Fr&eacute;do Durand</a> </p>
+<p> <a href="http://people.csail.mit.edu/billf/">Bill Freeman</a> </p>
+<p> <a href="http://www.cs.cmu.edu/~jhhays/">James Hays</a> </p>
+<p> <a href="http://homes.esat.kuleuven.be/~jknopp/">Jan Knopp</a> </p>
+<p> <a href="http://web.eecs.umich.edu/~fouhey/">David Fouhey</a> </p>
+<p> <a href="http://www.cs.cmu.edu/~mladenk/">Mladen Kolar</a> </p>
+<p> <a href="http://web.engr.illinois.edu/~slazebni/">Svetlana Lazebnik</a> </p>
+<p> <a href="http://www.cs.cmu.edu/~tmalisie/">Tomasz Malisiewicz</a> </p>
+<p> <a href="http://iris.usc.edu/~nevatia/">Ram Nevatia</a> </p>
+<p> <a href="http://cvcl.mit.edu/aude.htm">Aude Oliva</a> </p> <!-- ? -->
+<p> <a href="http://cis.jhu.edu/~rvidal/">Ren&eacute; Vidal</a> </p>

--- a/_includes/team/member.liquid
+++ b/_includes/team/member.liquid
@@ -16,20 +16,9 @@
 </div>
   {{ full_name }}</a><br>
   {{member[1].position}}
-  {% if member[1].alumni != true}
-  {% else %}
-    <br> Went to {{member[1].movedto}}
-  {% endif %}
 </div> -->
 
 <div class="member text-center {{member[1].position}}">
   <a href="{{ member[1].url }}" target="_blank"><img class="member-img-light w-100" alt="{{ full_name }}" src="{{ member[1].profilepic | prepend: '/assets/img/team/' | relative_url }}">
-  {% if member[1].alumni != true %}
     {{ full_name }}</a><br> ({{member[1].position}})
-  {% else %}
-    {{ full_name }}</a><br>{{member[1].position}}
-      {% if member[1].movedto != "none" %}
-        <br> <span class="movedto">(moved to {{member[1].movedto}})</span>
-      {% endif %}
-  {% endif %}
 </div>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -82,7 +82,7 @@ nav_order: 2
 
 
 <br>
-<h3 class="students" align="right">Visitors</h3>
+<h3 class="visitors" align="right">Visitors</h3>
 <div class="team">
 {% assign names_sorted = "" | split: ',' %}
 {% for member in site.data.team %}
@@ -99,25 +99,13 @@ nav_order: 2
 {% endfor %}
 </div>
 
-<!-- display Alumni in their data listing order -->
-<!-- could not manage to sort by alumni_date since Liquid does not allow modifying object w/o use of a plugin -->
-{% assign names_sorted = "" | split: ',' %}
-{% for member in site.data.team %}
-  {% if member[1].alumni == true %}
-    {% assign names_sorted = names_sorted | push: member[0] %}
-  {% endif %}
-{% endfor %}
-{% assign names_sorted = names_sorted | sort_natural %}
-{% if names_sorted.length > 0 %}
 <br>
 <br>
 <br>
 <h2 class="alumni" align="right">Alumni</h2>
-<div class="team alumni">
-{% for member in site.data.team %}
-  {% if member[1].alumni == true %}
-    {% include team/member.liquid member=member %}
-  {% endif %}
-{% endfor %}
-</div>
-{% endif %}
+
+{% include alumni.liquid %}
+
+<h2 class="former-visitors" align="right">Former Visitors</h2>
+
+{% include former_visitors.liquid %}


### PR DESCRIPTION
Instead of having to create >50 manual entries for Willow's alumni I removed the "alumni" tag from the entries in _data/team.yml and just copied the list over from the previous website. To add alumni, we can append to the files _include/alumni.liquid and _include/previous_visitors.liquid